### PR TITLE
corrección error asignar familia al crear personas.

### DIFF
--- a/02_code/conquermanager/create_data.py
+++ b/02_code/conquermanager/create_data.py
@@ -61,7 +61,8 @@ for i in range(20):
     last_name = last_names[i % len(last_names)]
     age = random.randint(12, 50)
     dni = f'{random.randint(10000000, 99999999)}{random.choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ")}'
-
+'''Me daba error al cargar el archivo, por lo que consulté y el problema que obtuve fué que 
+   a django no le gusta asignar una familia a la vez que se crea a la persona. 
     person = Person.objects.create(
         first_name=first_name,
         last_name=last_name,
@@ -69,3 +70,16 @@ for i in range(20):
         dni=dni,
         family=random.choice(Family.objects.all()),
     )
+La solución es:'''
+# Primero, creamos la persona sin asignarle una familia
+    person = Person.objects.create(
+        first_name=first_name,
+        last_name=last_name,
+        age=age,
+        dni=dni,
+    )
+
+# Luego, le asignamos una familia
+    chosen_family = random.choice(Family.objects.all())
+    person.family.set([chosen_family])
+


### PR DESCRIPTION
Buenos días,
He intentado hacer la carga del ejercicio desde consola, pero me daba un error: TypeError: Direct assignment to the forward side of a many-to-many set is prohibited. Use family.set() instead. Por lo que he quitado la última parte, y añadido por un lado la creación de la persona y por otro, la asignación de la familia. A ver qué te parece el cambio.